### PR TITLE
Option to defer highlighting until cursor moves away from a diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ local final_opts = {
   },
   extra_patterns = {},                                        -- Extra lua patterns to add. Does NOT override and will be added to the above
   diagnostic_handler_namespace = 'unused_hl_ns',              -- Name of the handler namespace that will contain the highlight (needs to be unique)
+  defer_until_n_lines_away = false,                           -- If set to a number, then highlighting is deferred until the cursor is N lines away from
+                                                              -- diagnostics. Useful to avoid unwanted highlights in the currently edited position.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ local final_opts = {
   diagnostic_handler_namespace = 'unused_hl_ns',              -- Name of the handler namespace that will contain the highlight (needs to be unique)
   defer_until_n_lines_away = false,                           -- If set to a number, then highlighting is deferred until the cursor is N lines away from
                                                               -- diagnostics. Useful to avoid unwanted highlights in the currently edited position.
+  defer_highlight_update_events = {'CursorHold', 'CursorHoldI'}, -- Events on which deferred highlights will be updated (passed to nvim_create_autocmd)
 }
 ```
 

--- a/lua/nvim-custom-diagnostic-highlight.lua
+++ b/lua/nvim-custom-diagnostic-highlight.lua
@@ -70,6 +70,7 @@ nvim_custom_diagnostic_highlight.setup = function(plugin_opts)
     extra_patterns = {},
     diagnostic_handler_namespace = 'unused_hl_ns',
     defer_until_n_lines_away = false,
+    defer_highlight_update_events = { 'CursorHold', 'CursorHoldI' },
   }
 
   for k, v in pairs(plugin_opts) do
@@ -132,7 +133,7 @@ nvim_custom_diagnostic_highlight.setup = function(plugin_opts)
             local autocmds_set = user_data.autocmds[bufnr]
 
             local id
-            id = vim.api.nvim_create_autocmd('CursorMoved', {
+            id = vim.api.nvim_create_autocmd(final_opts.defer_highlight_update_events, {
               group = augroup,
               buffer = bufnr,
               desc = 'Deferred custom diagnostic highlight',

--- a/lua/nvim-custom-diagnostic-highlight.lua
+++ b/lua/nvim-custom-diagnostic-highlight.lua
@@ -159,7 +159,7 @@ nvim_custom_diagnostic_highlight.setup = function(plugin_opts)
       vim.api.nvim_buf_clear_namespace(bufnr, user_data.hl_namespace, 0, -1)
 
       for id, _ in pairs(user_data.autocmds[bufnr] or {}) do
-        vim.api.nvim_del_autocmd(id)
+        pcall(vim.api.nvim_del_autocmd, id)
       end
       user_data.autocmds[bufnr] = {}
     end,


### PR DESCRIPTION
Hi, thanks for the plugin, this is cool idea. However, I noticed that when using it with Python, the diagnostic about unused variable covers the whole line, not only the variable name. This is annoying when still editing this line, e.g. I insert `for = bar(baz)` and as soon as I leave insert mode, the whole line goes gray. 

I thought it would be cool if the highlighting would be deferred if it happens near the cursor - it should wait until I move around a few lines. This PR adds an option `defer_until_n_lines_away` which, when set to a number, will implement what I described. This works by checking, for each diagnostic, if it lands near the cursor in current window. If it would, then a CursorMoved autocmd is created, which will keep checking if it's finally the time to do the highlighting. There is some additional logic to make sure we correctly clean up all these autocommands. 

Here's an example with `defer_until_n_lines_away = 3`: https://asciinema.org/a/6ONZjUJem9pe3oMgs5tzTEcsw

The code got a bit more complicated, so if you think that some additional refactoring would be needed, I can try to extract some more functions.